### PR TITLE
fix: raise error when invalid species or param entered for simulation

### DIFF
--- a/aiagents4pharma/talk2biomodels/models/basico_model.py
+++ b/aiagents4pharma/talk2biomodels/models/basico_model.py
@@ -58,19 +58,24 @@ class BasicoModel(SysBioModel):
             # check if the param_name is not None
             if param_name is None:
                 continue
-            # if param is a kinetic parameter
+            # Extract all parameters and species from the model
             df_all_params = basico.model_info.get_parameters(model=self.copasi_model)
+            df_all_species = basico.model_info.get_species(model=self.copasi_model)
+            # if param is a kinetic parameter
             if param_name in df_all_params.index.tolist():
                 basico.model_info.set_parameters(name=param_name,
                                             exact=True,
                                             initial_value=param_value,
                                             model=self.copasi_model)
             # if param is a species
-            else:
+            elif param_name in df_all_species.index.tolist():
                 basico.model_info.set_species(name=param_name,
                                             exact=True,
                                             initial_concentration=param_value,
                                             model=self.copasi_model)
+            else:
+                logger.error("Parameter/Species %s not found in the model.", param_name)
+                raise ValueError(f"Parameter/Species {param_name} not found in the model.")
 
     def simulate(self, duration: Union[int, float] = 10, interval: int = 10) -> pd.DataFrame:
         """

--- a/aiagents4pharma/talk2biomodels/tests/test_basico_model.py
+++ b/aiagents4pharma/talk2biomodels/tests/test_basico_model.py
@@ -26,8 +26,15 @@ def test_with_biomodel_id(model):
     assert df_parameters.loc['KmPFKF6P', 'initial_value'] == 1.5
     # check if the simulation results are a pandas DataFrame object
     assert isinstance(model.simulate(duration=2, interval=2), pd.DataFrame)
+    # Pass a None value to the update_parameters method
+    # and it should not raise an error
     model.update_parameters(parameters={None: None})
+    # check if the model description is updated
     assert model.description == basico.biomodels.get_model_info(model.biomodel_id)["description"]
+    # check if an error is raised if an invalid species/parameter (`Pyruv`)
+    # is passed and it should raise a ValueError
+    with pytest.raises(ValueError):
+        model.update_parameters(parameters={'Pyruv': 0.5})
 
 def test_with_sbml_file():
     """


### PR DESCRIPTION
# For authors

## Description

This update modifies the `basico_model` class to handle cases where species or parameter names in the prompt are incorrect. Previously, if a model contained *adenosine tri-phosphate* but the user wrote *ATP*, the agent would ignore the invalid species name and proceed as usual. Now, an error is raised, forcing the agent to either invoke the `get_modelinfo` tool to retrieve valid names or inform the user of the invalid input. This improves guidance, especially for users exploring the model.

## Fixes # (issue) NA

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests you conducted to verify your changes. These may involve creating new test scripts or updating existing ones.
- [ ] Added new test(s) in the ```tests``` folder
- [X] Added new function(s) to an existing test(s) (e.g.: ```tests/testX.py```)
- [ ] No new tests added (Please explain the rationale in this case)

## Checklist
- [X] My code follows the style guidelines mentioned in the Code/DevOps guides
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. MkDocs)
- [X] My changes generate no new warnings
- [X] I have added or updated tests (in the ```tests``` folder) that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# For reviewers

## Checklist pre-approval
- [ ] Is there enough documentation?  
- [ ] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
- [ ] Does the test(s) successfully test edge/corner cases?
- [ ] Does the PR pass the tests? (if the repository has continuous integration)

## Checklist post-approval
- [ ] Does this PR merge ```develop``` into ```main```? If so, please make sure to add a prefix (feat/fix/chore) and/or a suffix BREAKING CHANGE (if it's a major release) to your commit message.
- [ ] Does this PR close an issue? If so, please make sure to descriptively close this issue when the PR is merged.

## Checklist post-merge
- [ ] When you approve of the PR, merge and close it (Read this [article](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github) to know about different merge methods on GitHub)
- [ ] Did this PR merge ```develop``` into ```main``` and is it suppose to run an automated release workflow (if applicable)? If so, please make sure to check under the "Actions" tab to see if the workflow has been initiated, and return later to verify that it has completed successfully.
